### PR TITLE
gcp-disk-snapshot テスト用に tf を用意する

### DIFF
--- a/gcp-disk-snapshot/.gitignore
+++ b/gcp-disk-snapshot/.gitignore
@@ -1,0 +1,38 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+# tfvars はいれちゃう
+# *.tfvars
+#*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/gcp-disk-snapshot/README.md
+++ b/gcp-disk-snapshot/README.md
@@ -1,0 +1,22 @@
+# 2025/02 gcp-disk-snapshot
+
+https://zenn.dev/ganariya/scraps/c762810b8339f3
+
+GCP の disk snapshot の挙動がわからなかったため、適当な instance を立てたうえで試行錯誤しながら学びます。
+
+```
+cd gcp-disk-snapshot/terraform
+
+# setup ADC
+gcloud auth application-default login
+
+# terraform
+terraform init
+terraform plan --var 'project_id=your_project_id'
+terraform apply --var 'project_id=your_project_id'
+```
+
+## ref
+
+https://qiita.com/YSasago/items/a5eb1448114b3e177868
+https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk

--- a/gcp-disk-snapshot/terraform/.terraform.lock.hcl
+++ b/gcp-disk-snapshot/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.19.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:8YKQt+0YYI/sCcGVuJNqbnwsnijspeKZFm2WyOmgdhM=",
+    "zh:32ffeedd1131d81f290f4e4213b948c221f40d6b3b5e54b22781c2ed6e8ad3a5",
+    "zh:40b388e0356d849e6bf3f03be950f6bb7fa3e26a9a85977662f58f693a93901b",
+    "zh:5775262765dd66dae4886f3e8c85a39d4954892e352ce077e21f9310ffd6a9f4",
+    "zh:5e4626bdde902e35c97179a421fb303fa76e08ef89271275a40468d26f93a05e",
+    "zh:5fcc9482ec0b697f0d2223117f770e7eb6146837bf5d509b1ed59ae24ffd623f",
+    "zh:829e8bb61e4ac47e70138f7a381e9f0e6e51dc76d4f373fd0eb2da7d9d3d5968",
+    "zh:8baeab5b3bcafb03cb567302df6047580300b5881de9694c3fa40f4b6f6bf714",
+    "zh:a6a800d89e3dcbdcb5ba8bd87e981a1336785cdb206610581ba072828b2a83c4",
+    "zh:bf7620009f0a1b89756f2aa2a748db8bd0683947f26bb1999ba1c8c6479d1149",
+    "zh:d93b4202012672becf64473775330928c3cdf4471eb3db4502e7cca1badfbe6a",
+    "zh:dbeae2a0a11062d285964c0360c8f090cf260d163823c0f237396ce64900fb43",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/gcp-disk-snapshot/terraform/instance.tf
+++ b/gcp-disk-snapshot/terraform/instance.tf
@@ -1,0 +1,28 @@
+resource "google_compute_disk" "disk1" {
+  name  = "disk1"
+  zone  = var.zone
+  image = var.boot_image
+  size  = 10
+  type  = "pd-standard"
+  labels = {
+    purpose = "disk_snapshot_test"
+  }
+}
+
+resource "google_compute_instance" "instance1" {
+  name                      = "instance1"
+  machine_type              = "e2-micro" # 無料枠
+  zone                      = var.zone
+  allow_stopping_for_update = true # terraform がインスタンスを停止できるようにする（マシンタイプを変更できる）
+
+  boot_disk {
+    auto_delete = false
+    source      = google_compute_disk.disk1.self_link
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  deletion_protection = false
+}

--- a/gcp-disk-snapshot/terraform/provider.tf
+++ b/gcp-disk-snapshot/terraform/provider.tf
@@ -1,0 +1,13 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/gcp-disk-snapshot/terraform/terraform.tfvars
+++ b/gcp-disk-snapshot/terraform/terraform.tfvars
@@ -1,0 +1,3 @@
+region     = "asia-northeast1"
+zone       = "asia-northeast1-a"
+boot_image = "debian-cloud/debian-12"

--- a/gcp-disk-snapshot/terraform/variables.tf
+++ b/gcp-disk-snapshot/terraform/variables.tf
@@ -1,0 +1,12 @@
+variable "project_id" {
+  type = string
+}
+variable "region" {
+  type = string
+}
+variable "zone" {
+  type = string
+}
+variable "boot_image" {
+  type = string
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new deployment configuration that enables users to manage GCP disk snapshot setups with a dedicated compute disk and instance.
	- Provided customizable options for defining deployment parameters like region, zone, and boot image.

- **Documentation**
	- Updated the project guide to include step-by-step instructions for setting up the Google Cloud SDK and executing Terraform commands to initialize and apply the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->